### PR TITLE
Added support for 3 levels of child routes

### DIFF
--- a/src/server/renderUtils.js
+++ b/src/server/renderUtils.js
@@ -4,35 +4,6 @@ import { matchRoutes } from 'react-router-config';
 import { get500 } from '@server/views/htmlHelpers';
 import routes from '../client/pages/routes';
 
-// The components that we're declaring in pages.js are imported async, so we can't garantee that
-// they're loaded when we want to call loadData on the server and thus we need to import them
-// staticly/synchronously. This we do with an old-school require.
-const staticRoutes = routes.map((route) => {
-  const staticComponent = require(`../client/${route.componentPath}`).default;
-  if (route.routes) {
-    let staticChildren = route.routes.map((childRoute) => {
-      const staticComponent = require(`../client/${childRoute.componentPath}`)
-        .default;
-
-      return {
-        staticComponent,
-        ...childRoute,
-      };
-    });
-
-    return {
-      staticComponent,
-      ...route,
-      routes: staticChildren,
-    };
-  } else {
-    return {
-      staticComponent,
-      ...route,
-    };
-  }
-});
-
 export function preloadRouteData(req, store) {
   return Promise.all(getRoutePromises(req.url, store));
 }
@@ -69,4 +40,52 @@ export function preloadDataErrorHandler(err, res, req) {
     res.status(status).send(get500());
     console.error(`SERVER ERROR: ${err.toString()}`);
   }
+}
+
+// The components that we're declaring in pages.js are imported async, so we can't garantee that
+// they're loaded when we want to call loadData on the server and thus we need to import them
+// staticly/synchronously. This we do with an old-school require.
+// TODO: Make it recursive so it will support loadData for more than 3 levels of child routes
+const staticRoutes = routes.map((route) => {
+  const staticComponent = requireStaticComponent(route);
+
+  if (route.routes) {
+    let staticChildren = getMappedRoutes(route.routes);
+
+    return {
+      staticComponent,
+      ...route,
+      routes: staticChildren,
+    };
+  } else {
+    return {
+      staticComponent,
+      ...route,
+    };
+  }
+});
+
+function getMappedRoutes(routes) {
+  return routes.map((childRoute) => {
+    const staticComponent = requireStaticComponent(childRoute);
+
+    if (childRoute.routes) {
+      let staticChildren = getMappedRoutes(childRoute.routes);
+
+      return {
+        staticComponent,
+        ...childRoute,
+        routes: staticChildren,
+      };
+    } else {
+      return {
+        staticComponent,
+        ...childRoute,
+      };
+    }
+  });
+}
+
+function requireStaticComponent(route) {
+  return require(`../client/${route.componentPath}`).default;
 }

--- a/src/server/renderUtils.js
+++ b/src/server/renderUtils.js
@@ -13,7 +13,8 @@ function getRoutePromises(reqUrl, store) {
 
   const routePromises = matchedRoutePromises.reduce(
     (accumPromises, { route, match }) => {
-      const wrappedContainer = route.staticComponent.WrappedComponent;
+      const wrappedContainer =
+        route.staticComponent && route.staticComponent.WrappedComponent;
       if (wrappedContainer && wrappedContainer.loadData) {
         const parsedUrl = url.parse(reqUrl);
         accumPromises.push(


### PR DESCRIPTION
The static method to loadData now supports 3 levels. Need to make this recursive :/.

Now supports:
```
const routes = {
  Component: 'SomeBaseRoute',
  routes: [
    {
      Component: 'ChildRoute',
      routes: [
        {
          Component: 'GrandChildRoute',
          routes: [
            {
              Component: 'GrandGrandChildRoute',
              routes: [], // NOT SUPPORTED, these GrandGrandChildRoute cannot have a loadData
            },
          ],
        },
      ],
    },
  ],
};
```