### PR TITLE
Avoid scrollTo top if history update is caused by a history.replace. …

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -12,9 +12,9 @@ import AppFrame from './containers/appFrame/AppFrame';
 import 'shared/styles/base.scss';
 
 // Scroll to top on history change
-history.listen((location, action) => {
+history.listen((location) => {
   if (typeof window === 'object') {
-    if (action !== 'REPLACE') {
+    if (location.state?.dontScrollToTop !== true) {
       window.scrollTo(0, 0);
     }
   }

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -12,9 +12,11 @@ import AppFrame from './containers/appFrame/AppFrame';
 import 'shared/styles/base.scss';
 
 // Scroll to top on history change
-history.listen(() => {
+history.listen((location, action) => {
   if (typeof window === 'object') {
-    window.scrollTo(0, 0);
+    if (action !== 'REPLACE') {
+      window.scrollTo(0, 0);
+    }
   }
 });
 


### PR DESCRIPTION
…history.replace is used in Url components to update the url for triggering state changes, but we do not want to scroll to top when those components trigger a change. Another option is to pass a history.state but ended up using the replace action because wanted to avoid spamming the history object with tons of entries when changing the state, for example typing in a input that triggers url change will cause clicking the back button unusable because it removes one char at the time from the url as opposed to actually going to the previous page.