### PR TITLE
Add env vars from our .env file to prod build

### DIFF
--- a/webpack/server.prod.js
+++ b/webpack/server.prod.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const res = (p) => path.resolve(__dirname, p);
+const Dotenv = require('dotenv-webpack');
 
 const entry = res('../src/server/render.js');
 const output = res('../_build_prod/server');
@@ -101,6 +102,11 @@ module.exports = {
   plugins: [
     new webpack.optimize.LimitChunkCountPlugin({
       maxChunks: 1,
+    }),
+    new Dotenv({
+      path: path.resolve(__dirname, '../.env'),
+      systemvars: true,
+      safe: false,
     }),
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION
Is there a reason we dont want to do this?
The production server build wont be able to access `API_URL` in the .env file and thus breaking server fetching of data. Server will call: 'undefined/some-api-endpoint', if we dont add it. 

Of course, we could pass it in manually when starting the server, but that is not the usual setup? 🤔 